### PR TITLE
Handle empty BT response result  CharacteristicReadOperation

### DIFF
--- a/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/ble/RFSpyReader.java
+++ b/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/ble/RFSpyReader.java
@@ -129,6 +129,8 @@ public class RFSpyReader {
                             aapsLogger.error(LTag.PUMPBTCOMM, "FAIL: RileyLinkBLE reports operation already in progress");
                         } else if (result.resultCode == BLECommOperationResult.RESULT_NONE) {
                             aapsLogger.error(LTag.PUMPBTCOMM, "FAIL: got invalid result code: " + result.resultCode);
+                        } else if (result.resultCode == BLECommOperationResult.RESULT_EMPTY) {
+                            aapsLogger.error(LTag.PUMPBTCOMM, "FAIL: got invalid result code: " + result.resultCode);
                         }
                     } catch (InterruptedException e) {
                         aapsLogger.error(LTag.PUMPBTCOMM, "Interrupted while waiting for data");

--- a/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/ble/RileyLinkBLE.java
+++ b/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/ble/RileyLinkBLE.java
@@ -561,6 +561,8 @@ public class RileyLinkBLE {
                         rval.resultCode = BLECommOperationResult.RESULT_TIMEOUT;
                     } else if (mCurrentOperation.interrupted) {
                         rval.resultCode = BLECommOperationResult.RESULT_INTERRUPTED;
+                    } else if (mCurrentOperation.empty) {
+                        rval.resultCode = BLECommOperationResult.RESULT_EMPTY;
                     } else {
                         rval.resultCode = BLECommOperationResult.RESULT_SUCCESS;
                         rval.value = mCurrentOperation.getValue();

--- a/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/ble/operations/BLECommOperation.java
+++ b/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/ble/operations/BLECommOperation.java
@@ -14,6 +14,7 @@ public abstract class BLECommOperation {
 
     public boolean timedOut = false;
     public boolean interrupted = false;
+    public boolean empty = false;
     protected byte[] value;
     protected BluetoothGatt gatt;
     protected Semaphore operationComplete = new Semaphore(0, true);

--- a/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/ble/operations/BLECommOperationResult.java
+++ b/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/ble/operations/BLECommOperationResult.java
@@ -11,6 +11,8 @@ public class BLECommOperationResult {
     public static final int RESULT_BUSY = 3;
     public static final int RESULT_INTERRUPTED = 4;
     public static final int RESULT_NOT_CONFIGURED = 5;
+    public static final int RESULT_EMPTY = 6;
+
     public byte[] value;
     public int resultCode;
 }

--- a/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/ble/operations/CharacteristicReadOperation.java
+++ b/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/ble/operations/CharacteristicReadOperation.java
@@ -38,7 +38,13 @@ public class CharacteristicReadOperation extends BLECommOperation {
             if (didAcquire) {
                 SystemClock.sleep(1); // This is to allow the IBinder thread to exit before we continue, allowing easier
                 // understanding of the sequence of events.
-                // success
+                if (characteristic.getValue() == null && characteristic.getValue().length == 0) {
+                    // only set value on success
+                    aapsLogger.error(LTag.PUMPBTCOMM, "Received an empty result from gatt write operation");
+                    value = null;
+                    empty = true;
+                } else {
+                }
             } else {
                 aapsLogger.error(LTag.PUMPBTCOMM, "Timeout waiting for gatt write operation to complete");
                 timedOut = true;


### PR DESCRIPTION
In the current implementation, and empty response array in CharacteristicReadOperation.execute will be interpreted as a successful transmission (at this low level).

This is an exploration of how the code would be impacted if we were to introduce a `empty` state for this case, which would not be treated as successful at the level of CharacteristicReadOperation.